### PR TITLE
Release 0.0.2 with fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.json
+changes-verifier

--- a/codefresh/release-pipeline.yml
+++ b/codefresh/release-pipeline.yml
@@ -35,4 +35,4 @@ steps:
       release_tag: ${{CF_BRANCH}}
       draft: true
       files:
-        - '${{CF_VOLUME_PATH}}/${{CF_REPO_NAME}}/src/modified'
+        - '${{CF_VOLUME_PATH}}/${{CF_REPO_NAME}}/src/changes-verifier'

--- a/modified.yml
+++ b/modified.yml
@@ -1,14 +1,39 @@
 version: '1.0'
 kind: step-type
 metadata:
-  name: justforpersonalstudies/modified-files
+  name: justforpersonalstudies/changes-verifier
+  description: 'Step to check if a file has changed'
+  sources:
+    - 'https://github.com/fernando-msilva/changes-verifier'
   version: 0.0.1
   isPublic: true
   latest: true
 spec:
+  arguments: |-
+    {
+      "definitions": {},
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "additionalProperties": false,
+      "patterns": [],
+      "required": [
+        "FILE_NAME"
+      ],
+      "properties": {
+        "FILE_NAME": {
+          "type": "string",
+          "description": "file name to check if has changed"
+        }
+      }
+    }
   steps:
-    test:
+    verify:
       title: "just a test"
-      image: alpine
+      image: busybox:1.35.0
+      environment:
+        - 'FILE_NAME=${{FILE_NAME}}'
       commands:
-        - echo "hello world"
+        - wget -O /bin/changes-verifier https://github.com/fernando-msilva/changes-verifier/releases/download/v0.0.2/changes-verifier
+        - chmod +x /bin/changes-verifier
+        - echo "verify if $FILE_NAME has changed"
+        - cf_export HAS_CHANGES=$(changes-verifier $FILE_NAME)

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,3 +1,3 @@
-module modified
+module changes-verifier
 
 go 1.16

--- a/src/main.go
+++ b/src/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 )
@@ -12,14 +13,14 @@ type FilesChangeds struct {
 	} `json:"head_commit"`
 }
 
-func compareFiles(changeds []string, fileName string) {
+func compareFiles(changeds []string, fileName string) string {
 	for _, value := range changeds {
 		if value == fileName {
-			os.Exit(0)
+			return "true"
 		}
 	}
 
-	os.Exit(1)
+	return "false"
 }
 
 func main() {
@@ -29,5 +30,5 @@ func main() {
 	var teste FilesChangeds
 	json.Unmarshal(byteValue, &teste)
 	result := teste.HeadCommit.Modified
-	compareFiles(result, os.Args[1])
+	fmt.Println(compareFiles(result, os.Args[1]))
 }


### PR DESCRIPTION
Changing how to output verification result. Now the result is returned as string. Codefresh step pipeline has broken when trying to use exit code to know if file was changed.

Signed-off-by: fernando-msilva <fernandogbi96@gmail.com>